### PR TITLE
Updates README with proper links and examples 

### DIFF
--- a/rswag-api/lib/generators/rswag/api/install/install_generator.rb
+++ b/rswag-api/lib/generators/rswag/api/install/install_generator.rb
@@ -11,7 +11,7 @@ module Rswag
       end
 
       def add_routes
-        route("mount Rswag::Api::Engine => '/api-docs'")
+        route("mount OpenApi::Rswag::Api::Engine => '/api-docs'")
       end
     end
   end

--- a/rswag-specs/lib/generators/rswag/specs/install/templates/swagger_helper.rb
+++ b/rswag-specs/lib/generators/rswag/specs/install/templates/swagger_helper.rb
@@ -14,12 +14,22 @@ RSpec.configure do |config|
   # the root example_group in your specs, e.g. describe '...', swagger_doc: 'v2/swagger.json'
   config.swagger_docs = {
     'v1/swagger.json' => {
-      swagger: '2.0',
+      openapi: '3.0.0',
       info: {
         title: 'API V1',
         version: 'v1'
       },
-      paths: {}
+      paths: {},
+      servers: [
+        {
+          url: 'https://{defaultHost}',
+          variables: {
+            defaultHost: {
+                default: 'www.example.com'
+            }
+          }
+        }
+      ]
     }
   }
 end

--- a/rswag-specs/lib/open_api/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/open_api/rswag/specs/example_group_helpers.rb
@@ -41,7 +41,7 @@ module OpenApi
 
         # NICE TO HAVE
         # TODO: update generator templates to include 3.0 syntax
-        # TODO: setup travis CI?
+        # TODO: perform a tagged commit to trigger rubygem push for v 0.0.1
 
         # MUST HAVES
         # need to run ```npm install``` in rswag-ui dir to get assets to load

--- a/rswag-ui/lib/generators/rswag/ui/install/install_generator.rb
+++ b/rswag-ui/lib/generators/rswag/ui/install/install_generator.rb
@@ -11,7 +11,7 @@ module Rswag
       end
 
       def add_routes
-        route("mount Rswag::Ui::Engine => '/api-docs'")
+        route("mount OpenApi::Rswag::Ui::Engine => '/api-docs'")
       end
     end
   end


### PR DESCRIPTION
Updates README with proper links and examples for new OpenApi 3.0 syntax / features

Missed a few generator items as part of the rename