### PR TITLE
Remove hindrance for migrating to rails 6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,14 +4,14 @@ source 'https://rubygems.org'
 
 # Allow the rails version to come from an ENV setting so Travis can test multiple versions.
 # See http://www.schneems.com/post/50991826838/testing-against-multiple-rails-versions/
-rails_version = ENV['RAILS_VERSION'] || '5.1.2'
+rails_version = ENV['RAILS_VERSION'] || '5.2.3'
 
 gem 'rails', rails_version.to_s
 
 case rails_version.split('.').first
 when '3'
   gem 'strong_parameters'
-when '4', '5'
+when '4', '5', '6'
   gem 'responders'
 end
 

--- a/rswag-api/open_api-rswag-api.gemspec
+++ b/rswag-api/open_api-rswag-api.gemspec
@@ -13,5 +13,5 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{lib}/**/*"] + ["MIT-LICENSE", "Rakefile"]
 
-  s.add_dependency 'railties', '>= 3.1', '< 6.0'
+  s.add_dependency 'railties', '>= 3.1'
 end

--- a/rswag-api/open_api-rswag-api.gemspec
+++ b/rswag-api/open_api-rswag-api.gemspec
@@ -13,5 +13,5 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{lib}/**/*"] + ["MIT-LICENSE", "Rakefile"]
 
-  s.add_dependency 'railties', '>= 3.1'
+  s.add_dependency 'railties', '>= 3.1', '< 7.0'
 end

--- a/rswag-specs/open_api-rswag-specs.gemspec
+++ b/rswag-specs/open_api-rswag-specs.gemspec
@@ -15,9 +15,9 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{lib}/**/*'] + %w[MIT-LICENSE Rakefile]
 
-  s.add_dependency 'activesupport', '>= 3.1', '< 6.0'
+  s.add_dependency 'activesupport', '>= 3.1'
   s.add_dependency 'json-schema', '~> 2.2'
-  s.add_dependency 'railties', '>= 3.1', '< 6.0'
+  s.add_dependency 'railties', '>= 3.1'
   s.add_dependency 'hashie'
   s.add_development_dependency 'guard-rspec'
 end

--- a/rswag-specs/open_api-rswag-specs.gemspec
+++ b/rswag-specs/open_api-rswag-specs.gemspec
@@ -15,9 +15,9 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{lib}/**/*'] + %w[MIT-LICENSE Rakefile]
 
-  s.add_dependency 'activesupport', '>= 3.1'
+  s.add_dependency 'activesupport', '>= 3.1', '< 7.0'
   s.add_dependency 'json-schema', '~> 2.2'
-  s.add_dependency 'railties', '>= 3.1'
+  s.add_dependency 'railties', '>= 3.1', '< 7.0'
   s.add_dependency 'hashie'
   s.add_development_dependency 'guard-rspec'
 end

--- a/rswag-ui/open_api-rswag-ui.gemspec
+++ b/rswag-ui/open_api-rswag-ui.gemspec
@@ -13,6 +13,6 @@ Gem::Specification.new do |s|
 
   s.files = Dir.glob("{lib,node_modules}/**/*") + ["MIT-LICENSE", "Rakefile" ]
 
-  s.add_dependency 'actionpack', '>=3.1', '< 6.0'
-  s.add_dependency 'railties', '>= 3.1', '< 6.0'
+  s.add_dependency 'actionpack', '>=3.1'
+  s.add_dependency 'railties', '>= 3.1'
 end

--- a/rswag-ui/open_api-rswag-ui.gemspec
+++ b/rswag-ui/open_api-rswag-ui.gemspec
@@ -13,6 +13,6 @@ Gem::Specification.new do |s|
 
   s.files = Dir.glob("{lib,node_modules}/**/*") + ["MIT-LICENSE", "Rakefile" ]
 
-  s.add_dependency 'actionpack', '>=3.1'
-  s.add_dependency 'railties', '>= 3.1'
+  s.add_dependency 'actionpack', '>=3.1', '< 7.0'
+  s.add_dependency 'railties', '>= 3.1', '< 7.0'
 end


### PR DESCRIPTION
Hi, i'm using your gem and it's the only barrier that stops from migrating to rails 6. I want to switch back to your fork, what's why i created this pr.
Many thanks!