### PR TITLE
Point to the correct version of `rswag-specs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Once you have an API that can describe itself in Swagger, you've opened the trea
 
     group :test do
       gem 'rspec-rails'
-      gem 'rswag-specs'
+      gem 'open_api-rswag-specs'
     end
     ```
 


### PR DESCRIPTION
Using the old `rswag-specs` results in errors.