### PR TITLE
moves parameters to the components object

### DIFF
--- a/rswag-specs/lib/open_api/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/open_api/rswag/specs/request_factory.rb
@@ -51,8 +51,8 @@ module OpenApi
         end
 
         def resolve_parameter(ref, swagger_doc)
-          key = ref.sub('#/parameters/', '').to_sym
-          definitions = swagger_doc[:parameters]
+          key = ref.sub('#/components/parameters/', '').to_sym
+          definitions = swagger_doc.dig(:components, :parameters)
           raise "Referenced parameter '#{ref}' must be defined" unless definitions && definitions[key]
 
           definitions[key]


### PR DESCRIPTION
Reference can be found here:
https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.0.md#componentsObject

To be able to reuse parameters by defining them in the components object we will be another step closer to the spec :)