### PR TITLE
Allow multiple response examples to be defined per status code and content type

### DIFF
--- a/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
+++ b/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
@@ -170,7 +170,7 @@ module OpenApi
 
           it "delegates to 'context' with 'response' metadata" do
             expect(subject).to have_received(:context).with(
-                'success', response: { code: '201', description: 'success' }
+                'success', response: { code: '201', description: 'success', examples: {} }
             )
           end
         end
@@ -198,9 +198,14 @@ module OpenApi
         describe '#examples(example)' do
           let(:json_example) do
             {
-                'application/json' => {
-                    foo: 'bar'
+              'application/json' => {
+                'Some description' => {
+                  foo: 'bar'
+                },
+                'Another description' => {
+                  bar: 'baz'
                 }
+              }
             }
           end
           let(:api_metadata) { { response: {} } }

--- a/rswag-specs/spec/rswag/specs/swagger_formatter_spec.rb
+++ b/rswag-specs/spec/rswag/specs/swagger_formatter_spec.rb
@@ -28,7 +28,7 @@ module OpenApi
             {
                 path_item: { template: '/blogs' },
                 operation: { verb: :post, summary: 'Creates a blog' },
-                response: { code: '201', description: 'blog created' }
+                response: { code: '201', description: 'blog created', examples: {} }
             }
           end
 


### PR DESCRIPTION
For example:

```ruby
  response 422, 'invalid request' do
    example 'name is missing'
      let(:password) { 'secret' }
      run_test!
    end

    example 'password is missing' do
      let(:name) { 'bobby' }
      run_test!
    end

    example 'bad content type' do
      examples 'text/plain' => {
        error: 'bad content type'
      }
    end
  end
```

To be honest, much of this code feels like it's still suffering from an OpenAPI v2 hangover but I did the best I could! It'll hopefully improve over time.