### PR TITLE
Update middleware.rb

### DIFF
--- a/rswag-api/lib/open_api/rswag/api/middleware.rb
+++ b/rswag-api/lib/open_api/rswag/api/middleware.rb
@@ -24,7 +24,7 @@ module OpenApi
 
             return [
               '200',
-              { 'Content-Type' => 'mine' },
+              { 'Content-Type' => mime },
               [ body ]
             ]
           end


### PR DESCRIPTION
Looks like there was a typo referencing the `mime` variable.
Discovered while diffing across branches.