### PR TITLE
Bump to 0.1.0

### DIFF
--- a/rswag-api/open_api-rswag-api.gemspec
+++ b/rswag-api/open_api-rswag-api.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
   s.name        = "open_api-rswag-api"
-  s.version     = ENV['TRAVIS_TAG'] || '0.0.0'
+  s.version     = ENV['TRAVIS_TAG'] || '0.1.0'
   s.authors     = ["Richie Morris", "Jay Danielian"]
   s.email       = ["domaindrivendev@gmail.com"]
   s.homepage    = "https://github.com/jdanielian/open-api-rswag"

--- a/rswag-api/open_api-rswag-api.gemspec
+++ b/rswag-api/open_api-rswag-api.gemspec
@@ -13,5 +13,5 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{lib}/**/*"] + ["MIT-LICENSE", "Rakefile"]
 
-  s.add_dependency 'railties', '>= 3.1', '< 7.0'
+  s.add_dependency 'railties'
 end

--- a/rswag-specs/open_api-rswag-specs.gemspec
+++ b/rswag-specs/open_api-rswag-specs.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.push File.expand_path('lib', __dir__)
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
   s.name        = 'open_api-rswag-specs'
-  s.version     = ENV['TRAVIS_TAG'] || '0.0.0'
+  s.version     = ENV['TRAVIS_TAG'] || '0.1.0'
   s.authors     = ['Richie Morris', 'Jay Danielian']
   s.email       = ['domaindrivendev@gmail.com']
   s.homepage    = 'https://github.com/jdanielian/open-api-rswag'

--- a/rswag-specs/open_api-rswag-specs.gemspec
+++ b/rswag-specs/open_api-rswag-specs.gemspec
@@ -15,9 +15,9 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{lib}/**/*'] + %w[MIT-LICENSE Rakefile]
 
-  s.add_dependency 'activesupport', '>= 3.1', '< 7.0'
+  s.add_dependency 'activesupport'
   s.add_dependency 'json-schema', '~> 2.2'
-  s.add_dependency 'railties', '>= 3.1', '< 7.0'
+  s.add_dependency 'railties'
   s.add_dependency 'hashie'
   s.add_development_dependency 'guard-rspec'
 end

--- a/rswag-ui/open_api-rswag-ui.gemspec
+++ b/rswag-ui/open_api-rswag-ui.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
   s.name        = "open_api-rswag-ui"
-  s.version     = ENV['TRAVIS_TAG'] || '0.0.0'
+  s.version     = ENV['TRAVIS_TAG'] || '0.1.0'
   s.authors     = ["Richie Morris", "Jay Danielian"]
   s.email       = ["domaindrivendev@gmail.com"]
   s.homepage    = "https://github.com/jdanielian/open-api-rswag"

--- a/rswag-ui/open_api-rswag-ui.gemspec
+++ b/rswag-ui/open_api-rswag-ui.gemspec
@@ -13,6 +13,6 @@ Gem::Specification.new do |s|
 
   s.files = Dir.glob("{lib,node_modules}/**/*") + ["MIT-LICENSE", "Rakefile" ]
 
-  s.add_dependency 'actionpack', '>=3.1', '< 7.0'
-  s.add_dependency 'railties', '>= 3.1', '< 7.0'
+  s.add_dependency 'actionpack'
+  s.add_dependency 'railties'
 end

--- a/rswag/open_api-rswag.gemspec
+++ b/rswag/open_api-rswag.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
   s.name        = "open_api-rswag"
-  s.version     = ENV['TRAVIS_TAG'] || '0.0.0'
+  s.version     = ENV['TRAVIS_TAG'] || '0.1.0'
   s.authors     = ["Richie Morris", "Jay Danielian"]
   s.email       = ["domaindrivendev@gmail.com"]
   s.homepage    = "https://github.com/jdanielian/open-api-rswag"


### PR DESCRIPTION
Publish has build failures due to:

```
10.65 Your bundle is locked to open_api-rswag-api (0.0.0) from rubygems repository
10.65 https://rubygems.org/ or installed locally, but that version can no longer be
10.65 found in that source. That means the author of open_api-rswag-api (0.0.0) has
10.65 removed it. You'll need to update your bundle to a version other than
10.65 open_api-rswag-api (0.0.0) that hasn't been removed in order to install.
```

attempt to fix